### PR TITLE
Added new label ingress.certificate_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ By default a request would be redirected to `http://service-name:80/`.
 | `ingress.host` | `yes` | `-`      | When configured ingress is enabled. The hostname which should be mapped to the service. Wildcards `*` and regular expressions are allowed. |
 | `ingress.port` | `no`  | `80`    | The port which serves the service in the cluster. |
 | `ingress.virtual_proto` | `no`  | `http`     | The protocol used to connect to the backends |
+| `ingress.certificate_name` | `no`  | ``     | Custom name of ssl certificate used instead of domain name |
+
 
 ### Run a Service with Enabled Ingress
 
@@ -191,6 +193,25 @@ docker service create --name ingress \
   --mount type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock \
   --constraint node.role==manager \
   garutilorenzo/docker-swarm-ingress
+```
+
+#### Use custom certificate name
+
+Create the secrets with a custom name in this case is `wildcard-name.tld`:
+
+```
+docker secret create wildcard-name.tld.key my-service.key
+docker secret create wildcard-name.tld.crt my-service.crt
+```
+
+then use the label `ingress.certificate_name` to specify the custom certificate name:
+
+```
+docker service create --name my-service \
+  --network ingress-routing \
+  --label ingress.host=my-service.company.tld \
+  --label ingress.certificate_name=wildcard-name.tld \
+  nginx
 ```
 
 #### SSL Passthrough

--- a/nginx-ingress/Dockerfile
+++ b/nginx-ingress/Dockerfile
@@ -3,7 +3,9 @@ FROM nginx:1.21.6-alpine
 RUN apk add --update --no-cache python3 curl bash openssl && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
-RUN pip3 install docker-py==1.10.6 jinja2==3.1.2
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt\
+    && rm -rf ./requirements.txt
 ENV DOCKER_HOST "unix:///var/run/docker.sock"
 ENV UPDATE_INTERVAL "30"
 ENV DNS_UPDATE_INTERVAL "5"

--- a/nginx-ingress/Dockerfile
+++ b/nginx-ingress/Dockerfile
@@ -3,7 +3,7 @@ FROM nginx:1.21.6-alpine
 RUN apk add --update --no-cache python3 curl bash openssl && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
-RUN pip3 install docker-py jinja2
+RUN pip3 install docker-py==1.10.6 jinja2==3.1.2
 ENV DOCKER_HOST "unix:///var/run/docker.sock"
 ENV UPDATE_INTERVAL "30"
 ENV DNS_UPDATE_INTERVAL "5"

--- a/nginx-ingress/ingress/ingress.py
+++ b/nginx-ingress/ingress/ingress.py
@@ -94,7 +94,11 @@ while True:
             
             if service['Spec']['Labels'].get('ingress.virtual_proto'):
                 virtual_proto = ervice_port = service['Spec']['Labels'].get('ingress.virtual_proto', 'http')
-        
+            
+            certificate_name = None
+            if service['Spec']['Labels'].get('ingress.certificate_name'):
+                certificate_name = service['Spec']['Labels'].get('ingress.certificate_name')
+            
         out = {
             'http_config': http_config,
             'https_config': https_config,
@@ -104,7 +108,8 @@ while True:
             'alt_virtual_host': alt_virtual_host,
             'service_port': service_port,
             'service_name': service_name,
-            'service_id': service_id
+            'service_id': service_id,
+            'certificate_name': certificate_name
         }
 
         services_list.append(out)

--- a/nginx-ingress/ingress/nginx.tpl
+++ b/nginx-ingress/ingress/nginx.tpl
@@ -157,10 +157,14 @@ http {
 
         charset utf-8;
 
-        # SSL Settings        
+        # SSL Settings
+        {% if service.certificate_name -%}
+        ssl_certificate /run/secrets/{{ service['certificate_name'] }}.crt;
+        ssl_certificate_key /run/secrets/{{ service['certificate_name'] }}.key;
+        {% else %}
         ssl_certificate /run/secrets/{{ service['virtual_host'] }}.crt;
         ssl_certificate_key /run/secrets/{{ service['virtual_host'] }}.key;
-       
+        {% endif %}
         include /etc/nginx/options-ssl-nginx.conf;
         ssl_dhparam /etc/nginx/ssl-dhparams.pem;
 

--- a/nginx-ingress/requirements.txt
+++ b/nginx-ingress/requirements.txt
@@ -1,0 +1,6 @@
+docker-py==1.10.6
+docker-pycreds==0.4.0
+Jinja2==3.0.1
+MarkupSafe==2.0.1
+requests==2.26.0
+urllib3==1.26.7


### PR DESCRIPTION
Allow use of wildcard certificates.

Create the wildcard certificate with `docker secret create`:

```
docker secret create wildcard-name.tld.key my-service.key
docker secret create wildcard-name.tld.crt my-service.crt
```

Use certificate_name to specify the certificate name:

```
docker service create --name my-service \
  --network ingress-routing \
  --label ingress.host=my-service.company.tld \
  --label ingress.certificate_name=wildcard-name.tld \
  nginx
```